### PR TITLE
fix: docker compose up error on arm

### DIFF
--- a/scraper/requirements.txt
+++ b/scraper/requirements.txt
@@ -3,6 +3,6 @@ flask
 gunicorn
 python-dotenv
 celery
-gevent
+gevent==21.12.0
 redis
 pillow


### PR DESCRIPTION
An upstream dependency issue related to gevent causes the following build error on Mac ARM-based systems:

```
=> ERROR [scraper 4/9] RUN pip3 install --no-cache-dir -r /app/requirements.txt                                                                                          37.9s 
------                                                                                                                                                                          
 > [scraper 4/9] RUN pip3 install --no-cache-dir -r /app/requirements.txt:                                                                                                      
1.749 Collecting playwright                                                                                                                                                     
2.647   Downloading playwright-1.48.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (37.9 MB)                                                                       
18.81 Collecting flask                                                                                                                                                          
19.04   Downloading flask-3.0.3-py3-none-any.whl (101 kB)                                                                                                                       
19.72 Collecting gunicorn
19.97   Downloading gunicorn-23.0.0-py3-none-any.whl (85 kB)
20.51 Collecting python-dotenv
20.77   Downloading python_dotenv-1.0.1-py3-none-any.whl (19 kB)
21.26 Collecting celery
21.52   Downloading celery-5.5.3-py3-none-any.whl (438 kB)
22.56 Collecting gevent
22.85   Downloading gevent-24.2.1.tar.gz (6.1 MB)
25.22   Installing build dependencies: started
36.85   Installing build dependencies: finished with status 'done'
36.86   Getting requirements to build wheel: started
37.78   Getting requirements to build wheel: finished with status 'error'
37.78   ERROR: Command errored out with exit status 1:
37.78    command: /usr/bin/python3 /tmp/tmpnfrdtwnd get_requires_for_build_wheel /tmp/tmpgmyg6r0n
37.78        cwd: /tmp/pip-install-qntewmnd/gevent
37.78   Complete output (38 lines):
37.78   Compiling src/gevent/resolver/cares.pyx because it changed.
37.78   [1/1] Cythonizing src/gevent/resolver/cares.pyx
37.78   
37.78   Error compiling Cython file:
37.78   ------------------------------------------------------------
37.78   ...
37.78   cdef tuple integer_types
37.78   
37.78   if sys.version_info[0] >= 3:
37.78       integer_types = int,
37.78   else:
37.78       integer_types = (int, long)
37.78                             ^
37.78   ------------------------------------------------------------
37.78   src/gevent/libev/corecext.pyx:69:26: undeclared name not builtin: long
37.78   Compiling src/gevent/libev/corecext.pyx because it changed.
37.78   [1/1] Cythonizing src/gevent/libev/corecext.pyx
37.78   Traceback (most recent call last):
37.78     File "/tmp/tmpnfrdtwnd", line 280, in <module>
37.78       main()
37.78     File "/tmp/tmpnfrdtwnd", line 263, in main
37.78       json_out['return_val'] = hook(**hook_input['kwargs'])
37.78     File "/tmp/tmpnfrdtwnd", line 114, in get_requires_for_build_wheel
37.78       return hook(config_settings)
37.78     File "/tmp/pip-build-env-441mgt_p/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 333, in get_requires_for_build_wheel
37.78       return self._get_build_requires(config_settings, requirements=[])
37.78     File "/tmp/pip-build-env-441mgt_p/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 303, in _get_build_requires
37.78       self.run_setup()
37.78     File "/tmp/pip-build-env-441mgt_p/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 319, in run_setup
37.78       exec(code, locals())
37.78     File "<string>", line 54, in <module>
37.78     File "/tmp/pip-install-qntewmnd/gevent/_setuputils.py", line 249, in cythonize1
37.78       new_ext = cythonize(
37.78     File "/tmp/pip-build-env-441mgt_p/overlay/lib/python3.8/site-packages/Cython/Build/Dependencies.py", line 1153, in cythonize
37.78       cythonize_one(*args)
37.78     File "/tmp/pip-build-env-441mgt_p/overlay/lib/python3.8/site-packages/Cython/Build/Dependencies.py", line 1297, in cythonize_one
37.78       raise CompileError(None, pyx_file)
37.78   Cython.Compiler.Errors.CompileError: src/gevent/libev/corecext.pyx
37.78   ----------------------------------------
[+] Running 0/1mmand errored out with exit status 1: /usr/bin/python3 /tmp/tmpnfrdtwnd get_requires_for_build_wheel /tmp/tmpgmyg6r0n Check the logs for full command output.
 ⠇ Service scraper  Building                                                                                                                                             330.8s 
failed to solve: process "/bin/sh -c pip3 install --no-cache-dir -r /app/requirements.txt" did not complete successfully: exit code: 1
```

Reference: https://github.com/gevent/gevent/issues/1899

Pinning gevent to a specific version resolves this issue. I have verified that it now works correctly across all environments, which is exactly what this PR addresses.